### PR TITLE
Revamp the whole package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ serde = { version = "1", features = ["derive"] }
 regex = "1"
 lazy_static = "1"
 derive_more = "^0.99"
+typetag = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_dmx"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["general electrix <general.electrix@gmail.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ serial = "^0.4"
 serde = { version = "1", features = ["derive"] }
 regex = "1"
 lazy_static = "1"
+derive_more = "^0.99"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,10 @@
 name = "rust_dmx"
 version = "0.1.0"
 authors = ["general electrix <general.electrix@gmail.com>"]
+edition = "2018"
 
 [dependencies]
-serial = "*"
-serde = "*"
-serde_derive = "*"
-regex = "*"
-lazy_static = "*"
+serial = "^0.4"
+serde = { version = "1", features = ["derive"] }
+regex = "1"
+lazy_static = "1"

--- a/src/enttec.rs
+++ b/src/enttec.rs
@@ -1,5 +1,5 @@
 //! Implementation of support for the Enttec USB DMX Pro dongle.
-use regex::Regex;
+
 use std::cmp::min;
 use std::fmt;
 use std::fs;
@@ -173,7 +173,7 @@ impl DmxPortProvider for EnttecPortProvider {
         }
     }
     /// Attempt to open this port, and return it behind the trait object or an error.
-    fn open<N: Into<String>>(&self, port: N) -> Result<Box<DmxPort>, Error> {
-        EnttecDmxPort::new(port).map(|p| Box::new(p) as Box<DmxPort>)
+    fn open<N: Into<String>>(&self, port: N) -> Result<Box<dyn DmxPort>, Error> {
+        EnttecDmxPort::new(port).map(|p| Box::new(p) as Box<dyn DmxPort>)
     }
 }

--- a/src/enttec.rs
+++ b/src/enttec.rs
@@ -1,6 +1,6 @@
 //! Implementation of support for the Enttec USB DMX Pro dongle.
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer, __private::ser};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fs;
 use std::io::Write;
 use std::time::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,9 @@ pub trait DmxPort: fmt::Display {
     where
         Self: Sized;
 
-    /// Open the port for writing.
+    /// Open the port for writing.  Implementations should no-op if this is
+    /// called twice rather than returning an error.  Primarily used to re-open
+    /// a port that has be deserialized.
     fn open(&mut self) -> Result<(), Error>;
 
     /// Close the port.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use derive_more::Display;
 use serial::Error as SerialError;
 use std::error::Error as StdError;
+use std::fmt;
 
 mod enttec;
 mod offline;
@@ -10,7 +11,7 @@ pub use offline::OfflineDmxPort;
 
 /// Trait for the general notion of a DMX port.
 /// This enables creation of an "offline" port to slot into place if an API requires an output.
-pub trait DmxPort {
+pub trait DmxPort: fmt::Display {
     /// Return the available ports, and closures that can open them.
     fn available_ports() -> PortListing
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,193 +1,45 @@
-use serde::{Deserialize, Deserializer};
-use serde::{Serialize, Serializer};
+use derive_more::Display;
 use serial::Error as SerialError;
 use std::error::Error as StdError;
-use std::fmt;
 
 mod enttec;
+mod offline;
 
-pub use enttec::{EnttecDmxPort, EnttecPortProvider, ENTTEC_NAMESPACE};
+pub use enttec::EnttecDmxPort;
+pub use offline::OfflineDmxPort;
 
 /// Trait for the general notion of a DMX port.
 /// This enables creation of an "offline" port to slot into place if an API requires an output.
-pub trait DmxPort: fmt::Debug {
+pub trait DmxPort {
+    /// Return the available ports, and closures that can open them.
+    fn available_ports() -> PortListing
+    where
+        Self: Sized;
+
     /// Write a DMX frame out to the port.  If the frame is smaller than the minimum universe size,
     /// it will be padded with zeros.  If the frame is larger than the maximum universe size, the
     /// values beyond the max size will be ignored.
     fn write(&mut self, frame: &[u8]) -> Result<(), Error>;
-
-    /// Return the namespace this port lives in.
-    fn namespace(&self) -> &str;
-
-    /// Return the name of this port.  Should only be used for display purposes.
-    fn port_name(&self) -> &str;
-
-    /// Return a SerializablePort to be used to try to reopen a port
-    /// after deserialization of a saved show or after application restart.
-    fn serializable(&self) -> SerializablePort {
-        SerializablePort::new(self.namespace(), self.port_name())
-    }
 }
 
-/// A source of DmxPorts based on unique string identifiers.
-pub trait DmxPortProvider {
-    /// Return a unique namespace for this port provider.
-    fn namespace(&self) -> &str;
-    /// Return a description of the available ports provided by this provider.
-    fn available_ports(&self) -> Vec<String>;
-    /// Attempt to open this port, and return it behind the trait object or an error.
-    fn open<N: Into<String>>(&self, port: N) -> Result<Box<dyn DmxPort>, Error>;
-}
-
-pub struct OfflineDmxPort;
-
-impl fmt::Debug for OfflineDmxPort {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.serializable().fmt(f)
-    }
-}
-
-const OFFLINE_NAMESPACE: &'static str = "offline";
-const OFFLINE_ID: &'static str = "offline";
-
-impl DmxPort for OfflineDmxPort {
-    fn write(&mut self, _: &[u8]) -> Result<(), Error> {
-        Ok(())
-    }
-    fn namespace(&self) -> &str {
-        OFFLINE_NAMESPACE
-    }
-    fn port_name(&self) -> &str {
-        OFFLINE_ID
-    }
-}
-
-pub struct OfflinePortProvider;
-
-impl DmxPortProvider for OfflinePortProvider {
-    /// Return a unique namespace for this port provider.
-    fn namespace(&self) -> &str {
-        OFFLINE_NAMESPACE
-    }
-    /// Return a description of the available ports provided by this provider.
-    fn available_ports(&self) -> Vec<String> {
-        vec![OFFLINE_ID.to_string()]
-    }
-    /// Attempt to open this port, and return it behind the trait object or an error.
-    fn open<N: Into<String>>(&self, _: N) -> Result<Box<dyn DmxPort>, Error> {
-        Ok(Box::new(OfflineDmxPort))
-    }
-}
-
-/// Gather up all of the providers behind their namespace.
-/// This is your one-stop-shop for port creation.
-pub fn open_port<N: Into<String>>(namespace: &str, port_name: N) -> Result<Box<dyn DmxPort>, Error> {
-    match namespace {
-        OFFLINE_NAMESPACE => OfflinePortProvider.open(port_name),
-        ENTTEC_NAMESPACE => EnttecPortProvider.open(port_name),
-        _ => return Err(Error::InvalidNamespace(namespace.to_string())),
-    }
-}
+pub type PortOpener = dyn Fn() -> Result<Box<dyn DmxPort>, Error>;
+type PortListing = Vec<(String, Box<PortOpener>)>;
 
 /// Gather up all of the providers and use them to get listings of all ports they have available.
-/// Return them as a vector of pairs, each of which would be suitable to feed to open_port.
+/// Return them as a vector of names plus opener functions.
 /// This function does not check whether or not any of the ports are in use already.
-pub fn available_ports() -> Vec<(String, String)> {
+pub fn available_ports() -> PortListing {
     let mut ports = Vec::new();
-    fn add_ports<P: DmxPortProvider>(ports: &mut Vec<(String, String)>, provider: P) {
-        let namespace = provider.namespace();
-        let mut available = provider.available_ports();
-        for port_id in available.drain(..) {
-            ports.push((namespace.to_string(), port_id));
-        }
-    }
-    add_ports(&mut ports, OfflinePortProvider);
-    add_ports(&mut ports, EnttecPortProvider);
+    ports.extend(OfflineDmxPort::available_ports().into_iter());
+    ports.extend(EnttecDmxPort::available_ports().into_iter());
     ports
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-/// A serializable data structure for persisting a record of a port to disk, also providing
-/// for attempted reopening of a port.  Since we serialize and deserialize directly from disk,
-/// this data structure needs to own its data or Serde will fail upon deserialization as it isn't
-/// quite clever enough to figure out that this reference doesn't need to live beyond the
-/// deserialization step.
-pub struct SerializablePort {
-    namespace: String,
-    id: String,
-}
-
-impl SerializablePort {
-    fn new<N: Into<String>, I: Into<String>>(namespace: N, id: I) -> Self {
-        SerializablePort {
-            namespace: namespace.into(),
-            id: id.into(),
-        }
-    }
-
-    /// Try to open the port described by this serialized form.
-    fn open(self) -> Result<Box<dyn DmxPort>, Error> {
-        match self.namespace.as_str() {
-            OFFLINE_NAMESPACE => Ok(Box::new(OfflineDmxPort {})),
-            ENTTEC_NAMESPACE => Ok(Box::new(EnttecDmxPort::new(self.id)?)),
-            _ => Err(Error::InvalidNamespace(self.namespace.to_string())),
-        }
-    }
-
-    /// Based on the namespace and id, try to reopen this DMX port.
-    /// If we don't know the namespace or the port isn't available, return an offline port.
-    fn reopen(self) -> Box<dyn DmxPort> {
-        self.open().unwrap_or(Box::new(OfflineDmxPort {}))
-    }
-}
-
-// Helper functions to use when serializing and deserializing DmxPort trait objects contained in
-// other structs.  This can be done using the serde with attribute.
-pub fn serialize<S>(port: &Box<dyn DmxPort>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    port.serializable().serialize(serializer)
-}
-
-pub fn deserialize<'de, D>(deserializer: D) -> Result<Box<dyn DmxPort>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    SerializablePort::deserialize(deserializer).map(SerializablePort::reopen)
-}
-
-#[derive(Debug)]
+#[derive(Debug, Display)]
 pub enum Error {
     Serial(SerialError),
     IO(std::io::Error),
     InvalidNamespace(String),
-}
-
-/// We're ok with a loose equality comparison here.  Just delegate to description for now.
-impl PartialEq for Error {
-    fn eq(&self, other: &Self) -> bool {
-        use Error::*;
-        match (self, other) {
-            (&Serial(ref e0), &Serial(ref e1)) => e0.description() == e1.description(),
-            (&IO(ref e0), &IO(ref e1)) => e0.description() == e1.description(),
-            (&InvalidNamespace(ref n0), &InvalidNamespace(ref n1)) => n0 == n1,
-            _ => false,
-        }
-    }
-}
-
-impl Eq for Error {}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Error::*;
-        match *self {
-            Serial(ref e) => e.fmt(f),
-            IO(ref e) => e.fmt(f),
-            InvalidNamespace(ref n) => write!(f, "Invalid DMX port namesapce: '{}'.", n),
-        }
-    }
 }
 
 impl From<SerialError> for Error {
@@ -203,16 +55,7 @@ impl From<std::io::Error> for Error {
 }
 
 impl StdError for Error {
-    fn description(&self) -> &str {
-        use Error::*;
-        match *self {
-            Serial(ref e) => e.description(),
-            IO(ref e) => e.description(),
-            InvalidNamespace(_) => "Invalid DMX port namespace.",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn StdError> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         use Error::*;
         match *self {
             Serial(ref e) => Some(e),

--- a/src/offline.rs
+++ b/src/offline.rs
@@ -1,0 +1,22 @@
+use crate::{DmxPort, Error, PortOpener};
+
+use std::fmt;
+
+#[derive(Debug)]
+pub struct OfflineDmxPort;
+
+impl DmxPort for OfflineDmxPort {
+    fn available_ports() -> Vec<(String, Box<PortOpener>)> {
+        vec![("offline".to_string(), Box::new(|| Ok(Box::new(Self))))]
+    }
+
+    fn write(&mut self, _: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl fmt::Display for OfflineDmxPort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "offline")
+    }
+}

--- a/src/offline.rs
+++ b/src/offline.rs
@@ -1,14 +1,22 @@
 use crate::{DmxPort, Error, PortOpener};
+use serde::{Deserialize, Serialize};
 
 use std::fmt;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct OfflineDmxPort;
 
+#[typetag::serde]
 impl DmxPort for OfflineDmxPort {
     fn available_ports() -> Vec<(String, Box<PortOpener>)> {
         vec![("offline".to_string(), Box::new(|| Ok(Box::new(Self))))]
     }
+
+    fn open(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn close(&mut self) {}
 
     fn write(&mut self, _: &[u8]) -> Result<(), Error> {
         Ok(())


### PR DESCRIPTION
* Update dependencies and specify actual versions.
* Bump to 2018 edition and clean up.
* Collapse the port and port provider traits into a single trait.
* Replace the string-based namespace/name constructor system with anonymous constructor functions returned by available_ports.
* Move to a construct-then-open approach to allow ports to try to re-open after deserialization.
* Implement serialize/deserialize directly on the ports.
* Use typetag to support serializing `dyn DmxPort`.
* Re-use a single output buffer to eliminate an allocation from each enttec write cycle.
* Move the offline port into a separate module.