### PR TITLE
Windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["general electrix <general.electrix@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-serial = "^0.4"
+serialport = "4"
 serde = { version = "1", features = ["derive"] }
 regex = "1"
 lazy_static = "1"

--- a/src/enttec.rs
+++ b/src/enttec.rs
@@ -240,3 +240,24 @@ pub struct UsbPortInfoDef {
     pub manufacturer: Option<String>,
     pub product: Option<String>,
 }
+
+#[cfg(test)]
+mod test {
+    use std::{thread::sleep, time::Duration};
+
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn test() -> Result<(), Box<dyn Error>> {
+        let (_, open) = EnttecDmxPort::available_ports()?.pop().unwrap();
+        let mut port = open()?;
+        println!("{}", port);
+        for val in 0..255 {
+            port.write(&[val][..])?;
+            sleep(Duration::from_millis(25));
+        }
+        port.write(&[0][..])?;
+        Ok(())
+    }
+}

--- a/src/enttec.rs
+++ b/src/enttec.rs
@@ -129,7 +129,15 @@ impl DmxPort for EnttecDmxPort {
             .filter(|info| {
                 if let SerialPortType::UsbPort(usb_port_info) = &info.port_type {
                     if let Some(product) = &usb_port_info.product {
+                        // this should handle the unix case
+                        #[cfg(unix)]
                         return product == "DMX USB PRO";
+                        // the windows case, unfortunately, we do not have
+                        // enough details from the COM port interface to ensure that
+                        // we only include enttecs.  The best we can do is filter
+                        // down to FTDI ports.
+                        #[cfg(windows)]
+                        return product == "FTDI";
                     }
                 }
                 false

--- a/src/enttec.rs
+++ b/src/enttec.rs
@@ -1,7 +1,6 @@
 //! Implementation of support for the Enttec USB DMX Pro dongle.
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fs;
 use std::io::Write;
 use std::time::Duration;
 use std::{cmp::min, fmt};
@@ -9,8 +8,7 @@ use std::{cmp::min, fmt};
 use crate::{PortListing, PortOpener};
 
 use super::{DmxPort, Error};
-use serial::prelude::*;
-use serial::{open, SystemPort};
+use serialport::{available_ports, new, SerialPort, SerialPortInfo, SerialPortType, UsbPortInfo};
 
 // Some constants used for enttec message framing.
 const START_VAL: u8 = 0x7E;
@@ -41,7 +39,7 @@ fn make_packet(message_type: u8, payload: &[u8], output: &mut Vec<u8>) {
     output.push(END_VAL);
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct EnttecParams {
     /// DMX output break time in 10.67 microsecond units. Valid range is 9 to 127.
     break_time: u8,
@@ -75,32 +73,34 @@ impl EnttecParams {
     }
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct EnttecDmxPort {
     params: EnttecParams,
-    port: Option<SystemPort>,
-    port_name: String,
+    #[serde(skip)]
+    port: Option<Box<dyn SerialPort>>,
+    #[serde(with = "SerialPortInfoDef")]
+    info: SerialPortInfo,
+    #[serde(skip)]
     output_buffer: Vec<u8>,
 }
 
 impl EnttecDmxPort {
-    /// Create an enttec port with the specified port name.
+    /// Create an enttec port.
     /// The port is not opened yet.
-    pub fn new<N: Into<String>>(port_name: N) -> Self {
-        let port_name = port_name.into();
-
+    pub fn new(info: SerialPortInfo) -> Self {
         let params = EnttecParams::default();
 
         Self {
             params: params,
             port: None,
-            port_name: port_name,
+            info,
             output_buffer: Vec::new(),
         }
     }
 
-    /// Create an enttec port with the specified port name, and open it.
-    pub fn opened<N: Into<String>>(port_name: N) -> Result<Self, Error> {
-        let mut port = Self::new(port_name);
+    /// Create an enttec port and open it.
+    pub fn opened(info: SerialPortInfo) -> Result<Self, Error> {
+        let mut port = Self::new(info);
         port.open()?;
         Ok(port)
     }
@@ -125,28 +125,26 @@ impl EnttecDmxPort {
 impl DmxPort for EnttecDmxPort {
     /// Return the available enttec ports connected to this system.
     /// TODO: provide a mechanism to specialize this implementation depending on platform.
-    fn available_ports() -> PortListing {
-        match fs::read_dir("/dev/") {
-            Err(_) => Vec::new(),
-            Ok(dirs) => dirs
-                .filter_map(|x| x.ok())
-                .filter_map(|p| {
-                    p.path().to_str().and_then(|p| {
-                        if p.starts_with(ENTTEC_PATH_PREFIX) {
-                            let port_name = p[ENTTEC_PATH_PREFIX.len()..].to_string();
-                            let open_name = port_name.clone();
-                            let opener: Box<PortOpener> = Box::new(move || {
-                                EnttecDmxPort::opened(open_name.clone())
-                                    .map(|p| Box::new(p) as Box<dyn DmxPort>)
-                            });
-                            Some((port_name, opener))
-                        } else {
-                            None
-                        }
-                    })
-                })
-                .collect(),
-        }
+    fn available_ports() -> Result<PortListing, Error> {
+        Ok(available_ports()?
+            .into_iter()
+            .filter(|info| {
+                if let SerialPortType::UsbPort(usb_port_info) = &info.port_type {
+                    if let Some(product) = &usb_port_info.product {
+                        return product == "DMX USB PRO";
+                    }
+                }
+                false
+            })
+            .map(|info| {
+                let open_info = info.clone();
+                let opener: Box<PortOpener> = Box::new(move || {
+                    EnttecDmxPort::opened(open_info.clone())
+                        .map(|p| Box::new(p) as Box<dyn DmxPort>)
+                });
+                (info, opener)
+            })
+            .collect())
     }
 
     /// Open the port.
@@ -155,11 +153,10 @@ impl DmxPort for EnttecDmxPort {
             return Ok(());
         }
 
-        let port_path = format!("{}{}", ENTTEC_PATH_PREFIX, self.port_name);
-        let mut port = open(&port_path)?;
-
-        // use a short 1 ms timeout to avoid blocking if, say, the port disappears
-        port.set_timeout(Duration::from_millis(1))?;
+        // baud rate is not used on FTDI
+        let mut port = new(&self.info.port_name, 57600)
+            .timeout(Duration::from_millis(1))
+            .open()?;
 
         self.port = Some(port);
 
@@ -194,28 +191,46 @@ impl DmxPort for EnttecDmxPort {
     }
 }
 
-impl Serialize for EnttecDmxPort {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.port_name.serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for EnttecDmxPort {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(Self::new(String::deserialize(deserializer)?))
-    }
-}
-
-const ENTTEC_PATH_PREFIX: &'static str = "/dev/tty.usbserial-";
-
 impl fmt::Display for EnttecDmxPort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.port_name)
+        match &self.info.port_type {
+            SerialPortType::UsbPort(p) => {
+                if let Some(sn) = &p.serial_number {
+                    return write!(f, "Enttec DMX USB PRO {}", sn);
+                }
+            }
+            _ => (),
+        }
+        write!(f, "Enttec DMX USB PRO {}", self.info.port_name)
     }
+}
+
+// Derive serde for serial port info.
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "SerialPortInfo")]
+struct SerialPortInfoDef {
+    pub port_name: String,
+    #[serde(with = "SerialPortTypeDef")]
+    pub port_type: SerialPortType,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "SerialPortType")]
+pub enum SerialPortTypeDef {
+    #[serde(with = "UsbPortInfoDef")]
+    UsbPort(UsbPortInfo),
+    PciPort,
+    BluetoothPort,
+    Unknown,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "UsbPortInfo")]
+pub struct UsbPortInfoDef {
+    pub vid: u16,
+    pub pid: u16,
+    pub serial_number: Option<String>,
+    pub manufacturer: Option<String>,
+    pub product: Option<String>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,16 +80,14 @@ impl StdError for Error {
 
 #[cfg(test)]
 mod test {
-    use serialport::available_ports;
+    use super::*;
 
     #[test]
     fn test() {
-        let names = available_ports().unwrap();
-        // .unwrap()
-        // .into_iter()
-        // //.map(|port| port.port_name)
-        // .collect();
-        println!("{:?}", names);
-        assert!(false);
+        let (_, open) = available_ports().unwrap().pop().unwrap();
+        let mut port = open().unwrap();
+        let frame = [255, 255, 255];
+        port.write(&frame[..]).unwrap();
+        loop {}
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use derive_more::Display;
-use serialport::{Error as SerialError, SerialPortInfo};
+use serialport::Error as SerialError;
 use std::error::Error as StdError;
 use std::fmt;
 
@@ -13,7 +13,7 @@ pub use offline::OfflineDmxPort;
 /// This enables creation of an "offline" port to slot into place if an API requires an output.
 #[typetag::serde(tag = "type")]
 pub trait DmxPort: fmt::Display {
-    /// Return the available ports, and closures that can open them.
+    /// Return the available ports.  The ports will need to be opened before use.
     fn available_ports() -> Result<PortListing, Error>
     where
         Self: Sized;
@@ -32,11 +32,8 @@ pub trait DmxPort: fmt::Display {
     fn write(&mut self, frame: &[u8]) -> Result<(), Error>;
 }
 
-/// A closure that returns a fully-opened port.
-pub type PortOpener = dyn Fn() -> Result<Box<dyn DmxPort>, Error>;
-
-/// A listing of available ports, with opener functions.
-type PortListing = Vec<(SerialPortInfo, Box<PortOpener>)>;
+/// A listing of available ports.
+type PortListing = Vec<Box<dyn DmxPort>>;
 
 /// Gather up all of the providers and use them to get listings of all ports they have available.
 /// Return them as a vector of names plus opener functions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,17 +77,3 @@ impl StdError for Error {
         }
     }
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test() {
-        let (_, open) = available_ports().unwrap().pop().unwrap();
-        let mut port = open().unwrap();
-        let frame = [255, 255, 255];
-        port.write(&frame[..]).unwrap();
-        loop {}
-    }
-}

--- a/src/offline.rs
+++ b/src/offline.rs
@@ -1,5 +1,6 @@
 use crate::{DmxPort, Error, PortOpener};
 use serde::{Deserialize, Serialize};
+use serialport::{SerialPortInfo, SerialPortType};
 
 use std::fmt;
 
@@ -8,8 +9,14 @@ pub struct OfflineDmxPort;
 
 #[typetag::serde]
 impl DmxPort for OfflineDmxPort {
-    fn available_ports() -> Vec<(String, Box<PortOpener>)> {
-        vec![("offline".to_string(), Box::new(|| Ok(Box::new(Self))))]
+    fn available_ports() -> Result<Vec<(SerialPortInfo, Box<PortOpener>)>, Error> {
+        Ok(vec![(
+            SerialPortInfo {
+                port_name: "offline".to_string(),
+                port_type: SerialPortType::Unknown,
+            },
+            Box::new(|| Ok(Box::new(Self))),
+        )])
     }
 
     fn open(&mut self) -> Result<(), Error> {

--- a/src/offline.rs
+++ b/src/offline.rs
@@ -1,6 +1,5 @@
-use crate::{DmxPort, Error, PortOpener};
+use crate::{DmxPort, Error, PortListing};
 use serde::{Deserialize, Serialize};
-use serialport::{SerialPortInfo, SerialPortType};
 
 use std::fmt;
 
@@ -9,14 +8,8 @@ pub struct OfflineDmxPort;
 
 #[typetag::serde]
 impl DmxPort for OfflineDmxPort {
-    fn available_ports() -> Result<Vec<(SerialPortInfo, Box<PortOpener>)>, Error> {
-        Ok(vec![(
-            SerialPortInfo {
-                port_name: "offline".to_string(),
-                port_type: SerialPortType::Unknown,
-            },
-            Box::new(|| Ok(Box::new(Self))),
-        )])
+    fn available_ports() -> Result<PortListing, Error> {
+        Ok(vec![(Box::new(Self))])
     }
 
     fn open(&mut self) -> Result<(), Error> {


### PR DESCRIPTION
Replace `serial` with `serialport` to provide an available ports abstraction and easy Windows support.